### PR TITLE
#5 Changes the default Python 2 object from the (memoryview, buffer, ) t...

### DIFF
--- a/djorm_pgbytea/compat.py
+++ b/djorm_pgbytea/compat.py
@@ -9,4 +9,4 @@ else:
     if sys.platform.startswith('java'):
         buffer_type = (memoryview,)
     else:
-        buffer_type = (memoryview, buffer,)
+        buffer_type = (buffer,)


### PR DESCRIPTION
Changes the default Python 2 object from the (memoryview, buffer, ) to the (buffer) as Python 2.7 and Python 2.6 both have the buffer.

Otherwise this may generate an error.

This fix seems to work for me using Python 2.7 and Django 1.5.5.  
