### PR TITLE
Give LargeObjectField South support too

### DIFF
--- a/djorm_pgbytea/lobject.py
+++ b/djorm_pgbytea/lobject.py
@@ -91,3 +91,11 @@ class LargeObjectField(models.IntegerField):
             return None
 
         raise ValueError("Invalid value")
+
+
+# South support
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ['^djorm_pgbytea\.lobject\.LargeObjectField'])
+except ImportError:
+    pass


### PR DESCRIPTION
Just copied and pasted from  djorm_pgbytea/bytea.py and changed the rule regex
